### PR TITLE
Use CoreDNS instead of kubeDNS

### DIFF
--- a/templates/kops.yaml.tpl
+++ b/templates/kops.yaml.tpl
@@ -170,7 +170,8 @@ spec:
         - level: Metadata
           omitStages:
             - "RequestReceived"
-
+  kubeDNS:
+    provider: CoreDNS
   api:
     loadBalancer:
       type: Public


### PR DESCRIPTION
Migrate from kubeDNS to CoreDNS.

As of Kubernetes v1.12, CoreDNS is the recommended DNS Server, replacing kube-dns

https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#introduction 

