### PR TITLE
Additional security group for nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ resource "aws_security_group" "allow_tls" {
 
   tags = {
     Name = "additional-node-sg-${var.cluster_domain_name}",
-    KubernetesCluster = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+    KubernetesCluster = var.cluster_domain_name
   }
 }
 

--- a/templates/kops.yaml.tpl
+++ b/templates/kops.yaml.tpl
@@ -179,6 +179,8 @@ spec:
     rbac: {}
   channel: stable
   cloudProvider: aws
+  cloudConfig:
+    disableSecurityGroupIngress: true
   sshKeyName: ${cluster_domain_name}
   configBase: s3://${kops_state_store}/${cluster_domain_name}
   dnsZone: ${cluster_domain_name}
@@ -453,6 +455,7 @@ spec:
     owner: cloud-platform:platforms@digital.justice.gov.uk
     source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
   role: Node
+  securityGroupOverride: ${additonal_sg_id}
   subnets:
   - eu-west-2a
   - eu-west-2b

--- a/templates/kops.yaml.tpl
+++ b/templates/kops.yaml.tpl
@@ -455,7 +455,8 @@ spec:
     owner: cloud-platform:platforms@digital.justice.gov.uk
     source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
   role: Node
-  securityGroupOverride: ${additonal_sg_id}
+  additionalSecurityGroups: 
+  - ${additonal_sg_id}
   subnets:
   - eu-west-2a
   - eu-west-2b


### PR DESCRIPTION
AWS supports 60 rules for Security Group. Now that we are creating one Ingress-controller for namespace, kubernetes will add 3 rules for every load balancer so the limit will block us to move every ingress-controller to their namespace

Solution:

- Stop writing rules and add a generic rule to support all NLB services.
Using "disablesecuritygroupingress", kubernetes will stop writing rules to the SG.
https://github.com/kubernetes/kops/blob/release-1.9/docs/cluster_spec.md#disablesecuritygroupingress

- Add additional SG with a generic rule and assign it to node group.

This is related to [2288](https://github.com/ministryofjustice/cloud-platform/issues/2288) 