### PR TITLE
Define per-AZ instancegroups for worker nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,9 @@ resource "local_file" "kops" {
 
   content = templatefile("${path.module}/templates/kops.yaml.tpl", {
     cluster_domain_name                  = var.cluster_domain_name
-    cluster_node_count                   = var.cluster_node_count
+    cluster_node_count_a                 = var.cluster_node_count_a
+    cluster_node_count_b                 = var.cluster_node_count_b
+    cluster_node_count_c                 = var.cluster_node_count_c
     kops_state_store                     = var.kops_state_store
     oidc_issuer_url                      = var.oidc_issuer_url
     oidc_client_id                       = var.auth0_client_id

--- a/templates/kops.yaml.tpl
+++ b/templates/kops.yaml.tpl
@@ -423,7 +423,7 @@ spec:
 
 ########################################################################################################################################
 #                                                                                                                                      #
-# NOTE: This InstanceGroup must always be the last entry in this file, for the node-recycler.                                          #
+# NOTE: This multiple Availability Zone InstanceGroups must always be the last entry in this file, for the node-recycler.              #
 #                                                                                                                                      #
 # https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/091ff8cc054fb2f87734edef8de28dd31d71b0b2/recycle-node.rb#L85 #
 #                                                                                                                                      #

--- a/templates/kops.yaml.tpl
+++ b/templates/kops.yaml.tpl
@@ -435,15 +435,15 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: ${cluster_domain_name}
-  name: nodes-1.16.13
+  name: nodes-1.16.13-eu-west-2a
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: ${worker_node_machine_type}
-  maxSize: ${cluster_node_count}
-  minSize: ${cluster_node_count}
+  maxSize: ${cluster_node_count_a}
+  minSize: ${cluster_node_count_a}
   rootVolumeSize: 256
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes-1.16.13
+    kops.k8s.io/instancegroup: nodes-1.16.13-eu-west-2a
   cloudLabels:
     application: moj-cloud-platform
     business-unit: platforms
@@ -455,5 +455,61 @@ spec:
   role: Node
   subnets:
   - eu-west-2a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: ${cluster_domain_name}
+  name: nodes-1.16.13-eu-west-2b
+spec:
+  image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: ${worker_node_machine_type}
+  maxSize: ${cluster_node_count_b}
+  minSize: ${cluster_node_count_b}
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-1.16.13-eu-west-2b
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/${cluster_domain_name}: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  subnets:
   - eu-west-2b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: ${cluster_domain_name}
+  name: nodes-1.16.13-eu-west-2c
+spec:
+  image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: ${worker_node_machine_type}
+  maxSize: ${cluster_node_count_c}
+  minSize: ${cluster_node_count_c}
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-1.16.13-eu-west-2c
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/${cluster_domain_name}: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  subnets:
   - eu-west-2c

--- a/templates/kops.yaml.tpl
+++ b/templates/kops.yaml.tpl
@@ -423,7 +423,7 @@ spec:
 
 ########################################################################################################################################
 #                                                                                                                                      #
-# NOTE: Label "cloud-platform-recycle-nodes: true" in this multiple Availability Zone InstanceGroups, used for node-recycler.          #
+# NOTE: Label 'cloud-platform-recycle-nodes: "true"' in this multiple Availability Zone InstanceGroups, used for node-recycler.        #
 #                                                                                                                                      #
 # https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/091ff8cc054fb2f87734edef8de28dd31d71b0b2/recycle-node.rb#L93 #
 #                                                                                                                                      #
@@ -435,7 +435,7 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: ${cluster_domain_name}
-    cloud-platform-recycle-nodes: true
+    cloud-platform-recycle-nodes: "true"
   name: nodes-1.16.13-eu-west-2a
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
@@ -465,7 +465,7 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: ${cluster_domain_name}
-    cloud-platform-recycle-nodes: true
+    cloud-platform-recycle-nodes: "true"
   name: nodes-1.16.13-eu-west-2b
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
@@ -495,7 +495,7 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: ${cluster_domain_name}
-    cloud-platform-recycle-nodes: true
+    cloud-platform-recycle-nodes: "true"
   name: nodes-1.16.13-eu-west-2c
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17

--- a/templates/kops.yaml.tpl
+++ b/templates/kops.yaml.tpl
@@ -423,9 +423,9 @@ spec:
 
 ########################################################################################################################################
 #                                                                                                                                      #
-# NOTE: This multiple Availability Zone InstanceGroups must always be the last entry in this file, for the node-recycler.              #
+# NOTE: Label "cloud-platform-recycle-nodes: true" in this multiple Availability Zone InstanceGroups, used for node-recycler.          #
 #                                                                                                                                      #
-# https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/091ff8cc054fb2f87734edef8de28dd31d71b0b2/recycle-node.rb#L85 #
+# https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/091ff8cc054fb2f87734edef8de28dd31d71b0b2/recycle-node.rb#L93 #
 #                                                                                                                                      #
 ########################################################################################################################################
 
@@ -435,6 +435,7 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: ${cluster_domain_name}
+    cloud-platform-recycle-nodes: true
   name: nodes-1.16.13-eu-west-2a
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
@@ -464,6 +465,7 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: ${cluster_domain_name}
+    cloud-platform-recycle-nodes: true
   name: nodes-1.16.13-eu-west-2b
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
@@ -493,6 +495,7 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: ${cluster_domain_name}
+    cloud-platform-recycle-nodes: true
   name: nodes-1.16.13-eu-west-2c
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17

--- a/variables.tf
+++ b/variables.tf
@@ -29,9 +29,19 @@ variable "authorized_keys_manager" {
   description = "The authorized SSH keys that are going to be included in the cluster" 
 }
 
-variable "cluster_node_count" {
-  description = "The number of worker node in the cluster"
-  default     = "3"
+variable "cluster_node_count_a" {
+  description = "The number of worker node in the cluster in Availability Zone eu-west-2a"
+  default     = "1"
+}
+
+variable "cluster_node_count_b" {
+  description = "The number of worker node in the cluster in Availability Zone eu-west-2b"
+  default     = "1"
+}
+
+variable "cluster_node_count_c" {
+  description = "The number of worker node in the cluster in Availability Zone eu-west-2c"
+  default     = "1"
 }
 
 variable "master_node_machine_type" {


### PR DESCRIPTION
This is related to [2272](https://github.com/ministryofjustice/cloud-platform/issues/2272)

This will help to alter our kops config to control which AZ our worker nodes are created.