### PR TITLE
Dedicated node group for ingress controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ module "kops" {
   master_node_machine_type = lookup(var.master_node_machine_type, terraform.workspace, var.master_node_machine_type["default"])
   worker_node_machine_type = lookup(var.worker_node_machine_type, terraform.workspace, var.worker_node_machine_type["default"])
   enable_large_nodesgroup  = lookup(var.enable_large_nodesgroup, terraform.workspace, var.enable_large_nodesgroup["default"])
+  enable_ingress_nodesgroup  = lookup(var.enable_ingresse_nodesgroup, terraform.workspace, var.enable_ingress_nodesgroup["default"])
 
   template_path   = "../../../../kops"
   oidc_issuer_url = "https://${var.auth0_tenant_domain}/"
@@ -39,6 +40,7 @@ module "kops" {
 | master_node_machine_type | The AWS EC2 instance types to use for master nodes | string | - | no |
 | worker_node_machine_type | The AWS EC2 instance types to use for worker nodes | string |  | no |
 | enable_large_nodesgroup | Due to Prometheus resource consumption we added a larger node groups (r5.2xlarge), this variable you enable the creation of it | string | `` | no |
+| enable_ingress_nodesgroup | Production clusters now have their own dedicated nodes for ingress controllers. By setting this option to true, you will create a dedicated node for ingress | string | `` | no |
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ module "kops" {
   master_node_machine_type = lookup(var.master_node_machine_type, terraform.workspace, var.master_node_machine_type["default"])
   worker_node_machine_type = lookup(var.worker_node_machine_type, terraform.workspace, var.worker_node_machine_type["default"])
   enable_large_nodesgroup  = lookup(var.enable_large_nodesgroup, terraform.workspace, var.enable_large_nodesgroup["default"])
-  enable_ingress_nodesgroup  = lookup(var.enable_ingresse_nodesgroup, terraform.workspace, var.enable_ingress_nodesgroup["default"])
+  enable_ingress_nodesgroup  = lookup(var.enable_ingress_nodesgroup, terraform.workspace, var.enable_ingress_nodesgroup["default"])
 
   template_path   = "../../../../kops"
   oidc_issuer_url = "https://${var.auth0_tenant_domain}/"

--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,7 @@ resource "local_file" "kops" {
     worker_node_machine_type             = var.worker_node_machine_type
     master_node_machine_type             = var.master_node_machine_type
     enable_large_nodesgroup              = var.enable_large_nodesgroup
+    enable_ingress_nodesgroup            = var.enable_ingress_nodesgroup
   })
 }
 

--- a/templates/kops.yaml.tpl
+++ b/templates/kops.yaml.tpl
@@ -419,7 +419,102 @@ spec:
 
 %{ endif }
 
+%{ if enable_ingress_nodesgroup }
+
 ---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: ${cluster_domain_name}
+  name: ingress-nodes-1.17.12-eu-west-2a
+spec:
+  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
+  machineType: c5.xlarge
+  maxSize: 1
+  minSize: 1
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: ingress-nodes-1.17.12-eu-west-2a
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/${cluster_domain_name}: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  taints:
+  - ingress-node=true:NoSchedule
+  subnets:
+  - eu-west-2a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: ${cluster_domain_name}
+  name: ingress-nodes-1.17.12-eu-west-2b
+spec:
+  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
+  machineType: c5.xlarge
+  maxSize: 1
+  minSize: 1
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: ingress-nodes-1.17.12-eu-west-2b
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/${cluster_domain_name}: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  taints:
+  - ingress-node=true:NoSchedule
+  subnets:
+  - eu-west-2b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: ${cluster_domain_name}
+  name: ingress-nodes-1.17.12-eu-west-2c
+spec:
+  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
+  machineType: c5.xlarge
+  maxSize: 1
+  minSize: 1
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: ingress-nodes-1.17.12-eu-west-2c
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/${cluster_domain_name}: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  taints:
+  - ingress-node=true:NoSchedule
+  subnets:
+  - eu-west-2c
+
+%{ endif }
 
 ########################################################################################################################################
 #                                                                                                                                      #
@@ -428,6 +523,8 @@ spec:
 # https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/091ff8cc054fb2f87734edef8de28dd31d71b0b2/recycle-node.rb#L93 #
 #                                                                                                                                      #
 ########################################################################################################################################
+
+---
 
 apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup

--- a/variables.tf
+++ b/variables.tf
@@ -61,7 +61,7 @@ variable "enable_large_nodesgroup" {
 }
 
 variable "enable_ingress_nodesgroup" {
-  description = "Production clusters now have their own dedicated nodes for ingress controllers. By setting this option to true, you will create a dedicated node for ingress"
+  description = "Production clusters now have their own dedicated nodes for ingress controllers. By setting this option to true, three new nodes will be created."
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,28 +5,28 @@ variable "vpc_name" {
 
 variable "cluster_domain_name" {
   description = "The cluster domain used for externalDNS annotations and certmanager"
-  type = string
+  type        = string
 }
 
 variable "auth0_client_id" {
   description = ""
-  type = string
+  type        = string
 }
 
 variable "oidc_issuer_url" {}
 
 variable "template_path" {
-  type = string
+  type        = string
   description = "Path where the rendered templated is saved, the file is needed by create-cluster.rb script under kops/ folder"
 }
 
 variable "kops_state_store" {
-  type = string
+  type        = string
   description = "The S3 bucket where kops state is going to be saved"
 }
 
 variable "authorized_keys_manager" {
-  description = "The authorized SSH keys that are going to be included in the cluster" 
+  description = "The authorized SSH keys that are going to be included in the cluster"
 }
 
 variable "cluster_node_count_a" {
@@ -56,6 +56,12 @@ variable "worker_node_machine_type" {
 
 variable "enable_large_nodesgroup" {
   description = "Due to Prometheus resource consumption we added a larger node groups (r5.2xlarge), this variable you enable the creation of it"
+  type        = bool
+  default     = true
+}
+
+variable "enable_ingress_nodesgroup" {
+  description = "Production clusters now have their own dedicated nodes for ingress controllers. By setting this option to true, you will create a dedicated node for ingress"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
This allows you to set a variable to turn on/off dedicated ingress
controller nodes. Setting this to true will create three new nodes of
C5.xlarge instances. The ingress-controllers will not automatically
create on those nodes until you set an affinity label.