### PR TITLE
Enable cross-zone load-balancing

### DIFF
--- a/templates/kops.yaml.tpl
+++ b/templates/kops.yaml.tpl
@@ -175,6 +175,7 @@ spec:
   api:
     loadBalancer:
       type: Public
+      crossZoneLoadBalancing: true
   authorization:
     rbac: {}
   channel: stable


### PR DESCRIPTION
This should cause each node of the load-balancer to distribute traffic
across *all* worker nodes. Without it, each LB node (one per AZ) only
distributes traffic to worker nodes in the same AZ. This is a less
resilient configuration.

In testing, applying this change was extremely quick, and caused no
downtime to the test ingress, with a load test running while the change
was applied.

More info:
* https://github.com/kubernetes/kops/pull/6958
* https://gist.github.com/digitalronin/6a131807ff90b2835fd9d53092bde44b
* https://mojdt.slack.com/archives/C57UPMZLY/p1604482776372900
* https://console.aws.amazon.com/support/home#/case/?displayId=7467429111&language=en
